### PR TITLE
Add reported but unmodelled benefits

### DIFF
--- a/.github/workflows/lint.yml
+++ b/.github/workflows/lint.yml
@@ -25,4 +25,4 @@ jobs:
       - name: Black Code Formatter
         uses: lgeiger/black-action@v1.0.1
         with:
-          args: ". --check"
+          args: ". --check --line-length 79"

--- a/openfisca_uk/__init__.py
+++ b/openfisca_uk/__init__.py
@@ -15,7 +15,9 @@ class CountryTaxBenefitSystem(TaxBenefitSystem):
         super(CountryTaxBenefitSystem, self).__init__(entities.entities)
 
         # We add to our tax and benefit system all the variables
-        self.add_variables_from_directory(os.path.join(COUNTRY_DIR, "variables"))
+        self.add_variables_from_directory(
+            os.path.join(COUNTRY_DIR, "variables")
+        )
 
         # We add to our tax and benefit system all the legislation parameters defined in the  parameters files
         param_path = os.path.join(COUNTRY_DIR, "parameters")

--- a/openfisca_uk/reforms/basic_income/simulation_1.py
+++ b/openfisca_uk/reforms/basic_income/simulation_1.py
@@ -30,10 +30,18 @@ class basic_income(Variable):
     definition_period = ETERNITY
 
     def formula(person, period, parameters):
-        adult_young = (person("age", period) >= 16) * (person("age", period) < 24)
-        adult_old = (person("age", period) >= 24) * (person("age", period) < 65)
-        disabled_child = person("disabled", period) * person("is_child", period)
-        disabled_adult = person("disabled", period) * person("is_adult", period)
+        adult_young = (person("age", period) >= 16) * (
+            person("age", period) < 24
+        )
+        adult_old = (person("age", period) >= 24) * (
+            person("age", period) < 65
+        )
+        disabled_child = person("disabled", period) * person(
+            "is_child", period
+        )
+        disabled_adult = person("disabled", period) * person(
+            "is_adult", period
+        )
         return (
             person("is_senior", period) * 290
             + adult_young * 70
@@ -86,19 +94,36 @@ class family_net_income(Variable):
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
+        benefits = [
+            "child_tax_credit",
+            "working_tax_credit",
+            "child_benefit",
+            "income_support",
+            "housing_benefit_actual",
+            "contributory_JSA",
+            "income_JSA",
+            "DLA_SC_actual",
+            "DLA_M_actual",
+            "pension_credit_actual",
+            "BSP_actual",
+            "AFCS_actual",
+            "SDA_actual",
+            "AA_actual",
+            "carers_allowance_actual",
+            "IIDB_actual",
+            "ESA_actual",
+            "incapacity_benefit_actual",
+            "maternity_allowance_actual",
+            "guardians_allowance_actual",
+            "winter_fuel_payments_actual",
+        ]
         return (
             family("family_total_income", period)
-            + family("child_tax_credit", period)
-            + family("working_tax_credit", period)
-            + family("child_benefit", period)
-            + family("income_support", period)
-            + family("housing_benefit_actual", period)
-            + family("contributory_JSA", period)
-            + family("income_JSA", period)
+            + sum(map(lambda benefit: family(benefit, period), benefits))
+            + 25
             - family.sum(family.members("income_tax", period))
             - family.sum(family.members("NI", period))
             - family("benefit_cap_reduction", period)
-            + 25
         )
 
 

--- a/openfisca_uk/reforms/basic_income/simulation_2.py
+++ b/openfisca_uk/reforms/basic_income/simulation_2.py
@@ -9,8 +9,12 @@ def modify_parameters(parameters):
     file_path = os.path.join(
         dir_name, "parameters", "simulation_2", "new_income_tax.yaml"
     )
-    reform_parameters_subtree = load_parameter_file(file_path, name="new_income_tax")
-    parameters.taxes.income_tax.add_child("new_income_tax", reform_parameters_subtree)
+    reform_parameters_subtree = load_parameter_file(
+        file_path, name="new_income_tax"
+    )
+    parameters.taxes.income_tax.add_child(
+        "new_income_tax", reform_parameters_subtree
+    )
     return parameters
 
 
@@ -48,8 +52,12 @@ class basic_income(Variable):
     definition_period = ETERNITY
 
     def formula(person, period, parameters):
-        adult_young = (person("age", period) >= 16) * (person("age", period) < 24)
-        adult_old = (person("age", period) >= 24) * (person("age", period) < 65)
+        adult_young = (person("age", period) >= 16) * (
+            person("age", period) < 24
+        )
+        adult_old = (person("age", period) >= 24) * (
+            person("age", period) < 65
+        )
         return (
             person("is_senior", period) * 50
             + adult_young * 55
@@ -89,15 +97,32 @@ class family_net_income(Variable):
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
+        benefits = [
+            "child_tax_credit",
+            "working_tax_credit",
+            "child_benefit",
+            "income_support",
+            "housing_benefit_actual",
+            "contributory_JSA",
+            "income_JSA",
+            "DLA_SC_actual",
+            "DLA_M_actual",
+            "pension_credit_actual",
+            "BSP_actual",
+            "AFCS_actual",
+            "SDA_actual",
+            "AA_actual",
+            "carers_allowance_actual",
+            "IIDB_actual",
+            "ESA_actual",
+            "incapacity_benefit_actual",
+            "maternity_allowance_actual",
+            "guardians_allowance_actual",
+            "winter_fuel_payments_actual",
+        ]
         return (
             family("family_total_income", period)
-            + family("child_tax_credit", period)
-            + family("working_tax_credit", period)
-            + family("child_benefit", period)
-            + family("income_support", period)
-            + family("housing_benefit_actual", period)
-            + family("contributory_JSA", period)
-            + family("income_JSA", period)
+            + sum(map(lambda benefit: family(benefit, period), benefits))
             - family.sum(family.members("income_tax", period))
             - family.sum(family.members("NI", period))
             - family("benefit_cap_reduction", period)

--- a/openfisca_uk/reforms/basic_income/simulation_3.py
+++ b/openfisca_uk/reforms/basic_income/simulation_3.py
@@ -74,15 +74,32 @@ class family_net_income(Variable):
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
+        benefits = [
+            "child_tax_credit",
+            "working_tax_credit",
+            "child_benefit",
+            "income_support",
+            "housing_benefit_actual",
+            "contributory_JSA",
+            "income_JSA",
+            "DLA_SC_actual",
+            "DLA_M_actual",
+            "pension_credit_actual",
+            "BSP_actual",
+            "AFCS_actual",
+            "SDA_actual",
+            "AA_actual",
+            "carers_allowance_actual",
+            "IIDB_actual",
+            "ESA_actual",
+            "incapacity_benefit_actual",
+            "maternity_allowance_actual",
+            "guardians_allowance_actual",
+            "winter_fuel_payments_actual",
+        ]
         return (
             family("family_total_income", period)
-            + family("child_tax_credit", period)
-            + family("working_tax_credit", period)
-            + family("child_benefit", period)
-            + family("income_support", period)
-            + family("housing_benefit_actual", period)
-            + family("contributory_JSA", period)
-            + family("income_JSA", period)
+            + sum(map(lambda benefit: family(benefit, period), benefits))
             - family.sum(family.members("income_tax", period))
             - family.sum(family.members("NI", period))
             - family("benefit_cap_reduction", period)

--- a/openfisca_uk/reforms/basic_income/simulation_4.py
+++ b/openfisca_uk/reforms/basic_income/simulation_4.py
@@ -50,16 +50,33 @@ class family_net_income(Variable):
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
+        benefits = [
+            "family_basic_income",
+            "child_tax_credit",
+            "working_tax_credit",
+            "child_benefit",
+            "income_support",
+            "housing_benefit_actual",
+            "contributory_JSA",
+            "income_JSA",
+            "DLA_SC_actual",
+            "DLA_M_actual",
+            "pension_credit_actual",
+            "BSP_actual",
+            "AFCS_actual",
+            "SDA_actual",
+            "AA_actual",
+            "carers_allowance_actual",
+            "IIDB_actual",
+            "ESA_actual",
+            "incapacity_benefit_actual",
+            "maternity_allowance_actual",
+            "guardians_allowance_actual",
+            "winter_fuel_payments_actual",
+        ]
         return (
             family("family_total_income", period)
-            + family("child_tax_credit", period)
-            + family("working_tax_credit", period)
-            + family("child_benefit", period)
-            + family("income_support", period)
-            + family("housing_benefit_actual", period)
-            + family("contributory_JSA", period)
-            + family("income_JSA", period)
-            + family("family_basic_income", period)
+            + sum(map(lambda benefit: family(benefit, period), benefits))
             - family.sum(family.members("income_tax", period))
             - family.sum(family.members("NI", period))
             - family("benefit_cap_reduction", period)

--- a/openfisca_uk/variables/benefits.py
+++ b/openfisca_uk/variables/benefits.py
@@ -47,7 +47,8 @@ class contributory_JSA(Variable):
         single_old = (age >= 25) * (np.logical_not(is_couple))
         personal_allowance = (
             single_young * parameters(period).benefits.JSA.contrib.amount_18_24
-            + single_old * parameters(period).benefits.JSA.contrib.amount_over_25
+            + single_old
+            * parameters(period).benefits.JSA.contrib.amount_over_25
             + is_couple * parameters(period).benefits.JSA.contrib.amount_couple
         )
         earnings_deduction = max_(
@@ -86,7 +87,8 @@ class income_JSA(Variable):
         personal_allowance = (
             family("is_single", period)
             * (
-                (younger_age < 25) * parameters(period).benefits.JSA.income.amount_16_24
+                (younger_age < 25)
+                * parameters(period).benefits.JSA.income.amount_16_24
                 + (younger_age >= 25)
                 * parameters(period).benefits.JSA.income.amount_over_25
             )
@@ -110,9 +112,9 @@ class income_JSA(Variable):
                 * parameters(period).benefits.JSA.income.amount_lone_over_18
             )
         )
-        means_tested_income = family("family_post_tax_income", period) + family(
-            "contributory_JSA", period
-        )
+        means_tested_income = family(
+            "family_post_tax_income", period
+        ) + family("contributory_JSA", period)
         income_deduction = max_(
             0,
             means_tested_income
@@ -156,32 +158,44 @@ class income_support(Variable):
             * (
                 (younger_age < 18)
                 * (older_age < 18)
-                * parameters(period).benefits.income_support.amount_couples_16_17
+                * parameters(
+                    period
+                ).benefits.income_support.amount_couples_16_17
                 + (younger_age >= 18)
                 * (older_age >= 18)
-                * parameters(period).benefits.income_support.amount_couples_over_18
+                * parameters(
+                    period
+                ).benefits.income_support.amount_couples_over_18
                 + (younger_age < 18)
                 * (younger_age >= 25)
-                * parameters(period).benefits.income_support.amount_couples_age_gap
+                * parameters(
+                    period
+                ).benefits.income_support.amount_couples_age_gap
             )
             + family("is_lone_parent", period)
             * (
                 (younger_age < 18)
                 * parameters(period).benefits.income_support.amount_lone_16_17
                 + (younger_age >= 18)
-                * parameters(period).benefits.income_support.amount_lone_over_18
+                * parameters(
+                    period
+                ).benefits.income_support.amount_lone_over_18
             )
         )
-        means_tested_income = family("family_post_tax_income", period) + family(
-            "contributory_JSA", period
-        )
+        means_tested_income = family(
+            "family_post_tax_income", period
+        ) + family("contributory_JSA", period)
         income_deduction = max_(
             0,
             means_tested_income
             - family("is_single", period)
-            * parameters(period).benefits.income_support.income_disregard_single
+            * parameters(
+                period
+            ).benefits.income_support.income_disregard_single
             + family("is_couple", period)
-            * parameters(period).benefits.income_support.income_disregard_couple
+            * parameters(
+                period
+            ).benefits.income_support.income_disregard_couple
             + family("is_lone_parent", period)
             * parameters(period).benefits.income_support.income_disregard_lone,
         )
@@ -235,9 +249,13 @@ class child_tax_credit_pre_means_test(Variable):
         num_exempt_children = family.sum(
             family.members("is_CTC_child_limit_exempt", period)
         )
-        non_exempt_children = family.nb_persons(Family.CHILD) - num_exempt_children
+        non_exempt_children = (
+            family.nb_persons(Family.CHILD) - num_exempt_children
+        )
         spaces_left = max_(0, 2 - num_exempt_children)
-        children_eligible = num_exempt_children + min_(spaces_left, non_exempt_children)
+        children_eligible = num_exempt_children + min_(
+            spaces_left, non_exempt_children
+        )
         yearly_amount = (
             parameters(period).benefits.child_tax_credit.family_element
             + parameters(period).benefits.child_tax_credit.child_element
@@ -253,8 +271,12 @@ class child_working_tax_credit_reduction(Variable):
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
-        child_tax_credit_amount = family("child_tax_credit_pre_means_test", period)
-        working_tax_credit_amount = family("working_tax_credit_pre_means_test", period)
+        child_tax_credit_amount = family(
+            "child_tax_credit_pre_means_test", period
+        )
+        working_tax_credit_amount = family(
+            "working_tax_credit_pre_means_test", period
+        )
         eligible_for_both = (child_tax_credit_amount > 0) * (
             working_tax_credit_amount > 0
         )
@@ -267,7 +289,9 @@ class child_working_tax_credit_reduction(Variable):
         )
         reduction = (
             max_(0, (family("family_total_income", period) * 52 - threshold))
-            * parameters(period).benefits.child_tax_credit.income_reduction_rate
+            * parameters(
+                period
+            ).benefits.child_tax_credit.income_reduction_rate
         )
         return reduction
 
@@ -304,7 +328,8 @@ class child_tax_credit(Variable):
         return (
             max_(
                 0,
-                family("child_tax_credit_pre_means_test", period) + reduction_left,
+                family("child_tax_credit_pre_means_test", period)
+                + reduction_left,
             )
             / 52
         )
@@ -313,12 +338,18 @@ class child_tax_credit(Variable):
 class child_working_tax_credit_combined(Variable):
     value_type = float
     entity = Family
-    label = u"Child and Working Tax Credit amount received per week, means tested"
+    label = (
+        u"Child and Working Tax Credit amount received per week, means tested"
+    )
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
-        child_tax_credit_amount = family("child_tax_credit_pre_means_test", period)
-        working_tax_credit_amount = family("working_tax_credit_pre_means_test", period)
+        child_tax_credit_amount = family(
+            "child_tax_credit_pre_means_test", period
+        )
+        working_tax_credit_amount = family(
+            "working_tax_credit_pre_means_test", period
+        )
         eligible_for_both = (child_tax_credit_amount > 0) * (
             working_tax_credit_amount > 0
         )
@@ -331,7 +362,9 @@ class child_working_tax_credit_combined(Variable):
         )
         reduction = (
             max_(0, (family("family_total_income", period) * 52 - threshold))
-            * parameters(period).benefits.child_tax_credit.income_reduction_rate
+            * parameters(
+                period
+            ).benefits.child_tax_credit.income_reduction_rate
         )
         means_tested_amount = max_(
             0,
@@ -368,7 +401,9 @@ class benefit_cap_reduction(Variable):
 class working_tax_credit_pre_means_test(Variable):
     value_type = float
     entity = Family
-    label = u"Working Tax Credit amount received per year, before means testing"
+    label = (
+        u"Working Tax Credit amount received per year, before means testing"
+    )
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
@@ -411,3 +446,122 @@ class working_tax_credit_pre_means_test(Variable):
             * parameters(period).benefits.working_tax_credit.amount_lone_parent
         )
         return amount * eligible
+
+
+class DLA_SC_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Disability Living Allowance (self-care) per week"
+    definition_period = ETERNITY
+
+
+class DLA_M_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Disability Living Allowance (mobility)"
+    definition_period = ETERNITY
+
+
+class pension_credit_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Pension credit per week"
+    definition_period = ETERNITY
+
+
+class BSP_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Bereavement Support Payment / Widowed Parents Allowance per week"
+    definition_period = ETERNITY
+
+
+class AFCS_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Armed Forces Compensation Scheme per week"
+    definition_period = ETERNITY
+
+
+class SDA_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Severe Disability Allowance per week"
+    definition_period = ETERNITY
+
+
+class AA_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Attendance Allowance per week"
+    definition_period = ETERNITY
+
+
+class carers_allowance_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Carers Allowance per week"
+    definition_period = ETERNITY
+
+
+class IIDB_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Industrial Injury Disablement Benefit per week"
+    definition_period = ETERNITY
+
+
+class ESA_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Employment and Support Allowance per week"
+    definition_period = ETERNITY
+
+
+class incapacity_benefit_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Incapacity Benefit per week"
+    definition_period = ETERNITY
+
+
+class maternity_allowance_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Maternity Allowance per week"
+    definition_period = ETERNITY
+
+
+class guardians_allowance_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Guardians Allowance per week"
+    definition_period = ETERNITY
+
+
+class winter_fuel_payments_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Winter Fuel Payments per week"
+    definition_period = ETERNITY
+
+
+class universal_credit_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Universal Credit per week"
+    definition_period = ETERNITY
+
+
+class PIP_DL_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Personal Independence Payment (Daily Living) per week"
+    definition_period = ETERNITY
+
+
+class PIP_M_actual(Variable):
+    value_type = float
+    entity = Family
+    label = u"Amount of Personal Independence Payment (Mobility)"
+    definition_period = ETERNITY

--- a/openfisca_uk/variables/family.py
+++ b/openfisca_uk/variables/family.py
@@ -19,6 +19,13 @@ class family_weight(Variable):
 ## Family
 
 
+class rent(Variable):
+    value_type = float
+    entity = Family
+    label = u"Rental costs per week"
+    definition_period = ETERNITY
+
+
 class younger_adult_age(Variable):
     value_type = int
     entity = Family
@@ -194,15 +201,32 @@ class family_net_income(Variable):
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
+        benefits = [
+            "child_tax_credit",
+            "working_tax_credit",
+            "child_benefit",
+            "income_support",
+            "housing_benefit_actual",
+            "contributory_JSA",
+            "income_JSA",
+            "DLA_SC_actual",
+            "DLA_M_actual",
+            "pension_credit_actual",
+            "BSP_actual",
+            "AFCS_actual",
+            "SDA_actual",
+            "AA_actual",
+            "carers_allowance_actual",
+            "IIDB_actual",
+            "ESA_actual",
+            "incapacity_benefit_actual",
+            "maternity_allowance_actual",
+            "guardians_allowance_actual",
+            "winter_fuel_payments_actual",
+        ]
         return (
             family("family_total_income", period)
-            + family("child_tax_credit", period)
-            + family("working_tax_credit", period)
-            + family("child_benefit", period)
-            + family("income_support", period)
-            + family("housing_benefit_actual", period)
-            + family("contributory_JSA", period)
-            + family("income_JSA", period)
+            + sum(map(lambda benefit: family(benefit, period), benefits))
             - family.sum(family.members("income_tax", period))
             - family.sum(family.members("NI", period))
             - family("benefit_cap_reduction", period)

--- a/openfisca_uk/variables/family.py
+++ b/openfisca_uk/variables/family.py
@@ -18,6 +18,39 @@ class family_weight(Variable):
 
 ## Family
 
+class equivalised_income(Variable):
+    value_type = float
+    entity = Family
+    label = u'Equivalised income per week, accounting for family structure'
+    definition_period = ETERNITY
+
+    def formula(family, period, parameters):
+        second_adult = family.nb_persons(Family.ADULT) == 2
+        num_young_children = family.sum(family.members('is_young_child', period))
+        num_older_children = family.sum(family.members('is_older_child', period))
+        weighting = 0.67 + 0.33 * second_adult + 0.33 * num_older_children + 0.2 * num_young_children
+        return family('family_net_income', period) / weighting
+
+
+class in_absolute_poverty(Variable):
+    value_type = bool
+    entity = Family
+    label = u'Whether the family is in absolute poverty'
+    definition_period = ETERNITY
+    reference = ["https://www.ifs.org.uk/comms/comm118.pdf#page=7"]
+
+    def formula(family, period, parameters):
+        return family('equivalised_income', period) < 414
+
+class in_relative_poverty(Variable):
+    value_type = bool
+    entity = Family
+    label = u'Whether the family is in relative poverty'
+    definition_period = ETERNITY
+    reference = ["https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/875261/households-below-average-income-1994-1995-2018-2019.pdf#page=3"]
+
+    def formula(family, period, parameters):
+        return family('equivalised_income', period) < 447
 
 class rent(Variable):
     value_type = float

--- a/openfisca_uk/variables/family.py
+++ b/openfisca_uk/variables/family.py
@@ -18,39 +18,53 @@ class family_weight(Variable):
 
 ## Family
 
+
 class equivalised_income(Variable):
     value_type = float
     entity = Family
-    label = u'Equivalised income per week, accounting for family structure'
+    label = u"Equivalised income per week, accounting for family structure"
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
         second_adult = family.nb_persons(Family.ADULT) == 2
-        num_young_children = family.sum(family.members('is_young_child', period))
-        num_older_children = family.sum(family.members('is_older_child', period))
-        weighting = 0.67 + 0.33 * second_adult + 0.33 * num_older_children + 0.2 * num_young_children
-        return family('family_net_income', period) / weighting
+        num_young_children = family.sum(
+            family.members("is_young_child", period)
+        )
+        num_older_children = family.sum(
+            family.members("is_older_child", period)
+        )
+        weighting = (
+            0.67
+            + 0.33 * second_adult
+            + 0.33 * num_older_children
+            + 0.2 * num_young_children
+        )
+        return family("family_net_income", period) / weighting
 
 
 class in_absolute_poverty(Variable):
     value_type = bool
     entity = Family
-    label = u'Whether the family is in absolute poverty'
+    label = u"Whether the family is in absolute poverty"
     definition_period = ETERNITY
     reference = ["https://www.ifs.org.uk/comms/comm118.pdf#page=7"]
 
     def formula(family, period, parameters):
-        return family('equivalised_income', period) < 414
+        return family("equivalised_income", period) < 414
+
 
 class in_relative_poverty(Variable):
     value_type = bool
     entity = Family
-    label = u'Whether the family is in relative poverty'
+    label = u"Whether the family is in relative poverty"
     definition_period = ETERNITY
-    reference = ["https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/875261/households-below-average-income-1994-1995-2018-2019.pdf#page=3"]
+    reference = [
+        "https://assets.publishing.service.gov.uk/government/uploads/system/uploads/attachment_data/file/875261/households-below-average-income-1994-1995-2018-2019.pdf#page=3"
+    ]
 
     def formula(family, period, parameters):
-        return family('equivalised_income', period) < 447
+        return family("equivalised_income", period) < 447
+
 
 class rent(Variable):
     value_type = float

--- a/openfisca_uk/variables/person.py
+++ b/openfisca_uk/variables/person.py
@@ -120,20 +120,22 @@ class age(Variable):
             + (band == 16) * 80
         )
 
+
 class is_young_child(Variable):
     value_type = bool
     entity = Person
-    label = u'Whether the person is under 14'
+    label = u"Whether the person is under 14"
     definition_period = ETERNITY
 
     def formula(person, period, parameters):
-        return person('age', period) < 14
+        return person("age", period) < 14
+
 
 class is_older_child(Variable):
     value_type = bool
     entity = Person
-    label = u'Whether the person is over 14 but under 18'
+    label = u"Whether the person is over 14 but under 18"
     definition_period = ETERNITY
 
     def formula(person, period, parameters):
-        return (person('age', period) >= 14) * (person('age', period) < 18)
+        return (person("age", period) >= 14) * (person("age", period) < 18)

--- a/openfisca_uk/variables/person.py
+++ b/openfisca_uk/variables/person.py
@@ -22,7 +22,9 @@ class is_state_pension_age(Variable):
             >= parameters(period).benefits.state_pension.male_state_pension_age
         ) + (1 - person("is_male", period)) * (
             person("age", period)
-            >= parameters(period).benefits.state_pension.female_state_pension_age
+            >= parameters(
+                period
+            ).benefits.state_pension.female_state_pension_age
         )
 
 

--- a/openfisca_uk/variables/person.py
+++ b/openfisca_uk/variables/person.py
@@ -119,3 +119,21 @@ class age(Variable):
             + (band == 15) * 73
             + (band == 16) * 80
         )
+
+class is_young_child(Variable):
+    value_type = bool
+    entity = Person
+    label = u'Whether the person is under 14'
+    definition_period = ETERNITY
+
+    def formula(person, period, parameters):
+        return person('age', period) < 14
+
+class is_older_child(Variable):
+    value_type = bool
+    entity = Person
+    label = u'Whether the person is over 14 but under 18'
+    definition_period = ETERNITY
+
+    def formula(person, period, parameters):
+        return (person('age', period) >= 14) * (person('age', period) < 18)

--- a/openfisca_uk/variables/taxes.py
+++ b/openfisca_uk/variables/taxes.py
@@ -115,8 +115,10 @@ class capital_gains_tax(Variable):
             - parameters(period).taxes.capital_gains_tax.higher_threshold,
         )
         yearly_tax = (
-            basic_amount * parameters(period).taxes.capital_gains_tax.basic_rate
-            + higher_amount * parameters(period).taxes.capital_gains_tax.higher_rate
+            basic_amount
+            * parameters(period).taxes.capital_gains_tax.basic_rate
+            + higher_amount
+            * parameters(period).taxes.capital_gains_tax.higher_rate
         )
         return yearly_tax / 52
 
@@ -129,18 +131,26 @@ class NI(Variable):
     reference = ["https://www.gov.uk/national-insurance"]
 
     def formula(person, period, parameters):
-        employee_NI = parameters(period).taxes.national_insurance.employee_rates.calc(
+        employee_NI = parameters(
+            period
+        ).taxes.national_insurance.employee_rates.calc(
             person("employee_earnings", period)
         )
-        estimated_yearly_self_emp = person("self_employed_earnings", period) * 52
+        estimated_yearly_self_emp = (
+            person("self_employed_earnings", period) * 52
+        )
         self_employed_NI_basic = parameters(
             period
         ).taxes.national_insurance.self_employed_basic * (
             estimated_yearly_self_emp
-            > parameters(period).taxes.national_insurance.self_employed_basic_threshold
+            > parameters(
+                period
+            ).taxes.national_insurance.self_employed_basic_threshold
         )
         self_employed_NI_higher = (
-            parameters(period).taxes.national_insurance.self_employed_higher.calc(
+            parameters(
+                period
+            ).taxes.national_insurance.self_employed_higher.calc(
                 estimated_yearly_self_emp
             )
             / 52
@@ -162,8 +172,13 @@ class personal_allowance(Variable):
         estimated_yearly_income = (person("taxable_income", period)) * 52
         pa_deduction = parameters(
             period
-        ).taxes.income_tax.personal_allowance_deduction.calc(estimated_yearly_income)
-        return parameters(period).taxes.income_tax.personal_allowance - pa_deduction
+        ).taxes.income_tax.personal_allowance_deduction.calc(
+            estimated_yearly_income
+        )
+        return (
+            parameters(period).taxes.income_tax.personal_allowance
+            - pa_deduction
+        )
 
 
 class income_tax(Variable):
@@ -176,7 +191,11 @@ class income_tax(Variable):
         estimated_yearly_income = (person("taxable_income", period)) * 52
         weekly_tax = (
             parameters(period).taxes.income_tax.income_tax.calc(
-                max_(estimated_yearly_income - person("personal_allowance", period), 0)
+                max_(
+                    estimated_yearly_income
+                    - person("personal_allowance", period),
+                    0,
+                )
             )
         ) / 52
         return weekly_tax


### PR DESCRIPTION
This adds input variables for all other weekly benefits in the FRS, such as Severe Disability Allowance, Maternity Allowance and more bespoke benefits. Also, the linting has been set at 79 characters per line.