### PR TITLE
Separate benefit sum from net income variable

### DIFF
--- a/openfisca_uk/reforms/basic_income/simulation_1.py
+++ b/openfisca_uk/reforms/basic_income/simulation_1.py
@@ -94,32 +94,10 @@ class family_net_income(Variable):
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
-        benefits = [
-            "child_tax_credit",
-            "working_tax_credit",
-            "child_benefit",
-            "income_support",
-            "housing_benefit_actual",
-            "contributory_JSA",
-            "income_JSA",
-            "DLA_SC_actual",
-            "DLA_M_actual",
-            "pension_credit_actual",
-            "BSP_actual",
-            "AFCS_actual",
-            "SDA_actual",
-            "AA_actual",
-            "carers_allowance_actual",
-            "IIDB_actual",
-            "ESA_actual",
-            "incapacity_benefit_actual",
-            "maternity_allowance_actual",
-            "guardians_allowance_actual",
-            "winter_fuel_payments_actual",
-        ]
+
         return (
             family("family_total_income", period)
-            + sum(map(lambda benefit: family(benefit, period), benefits))
+            + family("total_benefit_value", period)
             + 25
             - family.sum(family.members("income_tax", period))
             - family.sum(family.members("NI", period))

--- a/openfisca_uk/reforms/basic_income/simulation_2.py
+++ b/openfisca_uk/reforms/basic_income/simulation_2.py
@@ -97,32 +97,10 @@ class family_net_income(Variable):
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
-        benefits = [
-            "child_tax_credit",
-            "working_tax_credit",
-            "child_benefit",
-            "income_support",
-            "housing_benefit_actual",
-            "contributory_JSA",
-            "income_JSA",
-            "DLA_SC_actual",
-            "DLA_M_actual",
-            "pension_credit_actual",
-            "BSP_actual",
-            "AFCS_actual",
-            "SDA_actual",
-            "AA_actual",
-            "carers_allowance_actual",
-            "IIDB_actual",
-            "ESA_actual",
-            "incapacity_benefit_actual",
-            "maternity_allowance_actual",
-            "guardians_allowance_actual",
-            "winter_fuel_payments_actual",
-        ]
+
         return (
             family("family_total_income", period)
-            + sum(map(lambda benefit: family(benefit, period), benefits))
+            + family("total_benefit_value", period)
             - family.sum(family.members("income_tax", period))
             - family.sum(family.members("NI", period))
             - family("benefit_cap_reduction", period)

--- a/openfisca_uk/reforms/basic_income/simulation_3.py
+++ b/openfisca_uk/reforms/basic_income/simulation_3.py
@@ -74,32 +74,9 @@ class family_net_income(Variable):
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
-        benefits = [
-            "child_tax_credit",
-            "working_tax_credit",
-            "child_benefit",
-            "income_support",
-            "housing_benefit_actual",
-            "contributory_JSA",
-            "income_JSA",
-            "DLA_SC_actual",
-            "DLA_M_actual",
-            "pension_credit_actual",
-            "BSP_actual",
-            "AFCS_actual",
-            "SDA_actual",
-            "AA_actual",
-            "carers_allowance_actual",
-            "IIDB_actual",
-            "ESA_actual",
-            "incapacity_benefit_actual",
-            "maternity_allowance_actual",
-            "guardians_allowance_actual",
-            "winter_fuel_payments_actual",
-        ]
         return (
             family("family_total_income", period)
-            + sum(map(lambda benefit: family(benefit, period), benefits))
+            + family("total_benefit_value", period)
             - family.sum(family.members("income_tax", period))
             - family.sum(family.members("NI", period))
             - family("benefit_cap_reduction", period)

--- a/openfisca_uk/reforms/basic_income/simulation_4.py
+++ b/openfisca_uk/reforms/basic_income/simulation_4.py
@@ -50,33 +50,9 @@ class family_net_income(Variable):
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
-        benefits = [
-            "family_basic_income",
-            "child_tax_credit",
-            "working_tax_credit",
-            "child_benefit",
-            "income_support",
-            "housing_benefit_actual",
-            "contributory_JSA",
-            "income_JSA",
-            "DLA_SC_actual",
-            "DLA_M_actual",
-            "pension_credit_actual",
-            "BSP_actual",
-            "AFCS_actual",
-            "SDA_actual",
-            "AA_actual",
-            "carers_allowance_actual",
-            "IIDB_actual",
-            "ESA_actual",
-            "incapacity_benefit_actual",
-            "maternity_allowance_actual",
-            "guardians_allowance_actual",
-            "winter_fuel_payments_actual",
-        ]
         return (
             family("family_total_income", period)
-            + sum(map(lambda benefit: family(benefit, period), benefits))
+            + family("total_benefit_value", period)
             - family.sum(family.members("income_tax", period))
             - family.sum(family.members("NI", period))
             - family("benefit_cap_reduction", period)

--- a/openfisca_uk/variables/family.py
+++ b/openfisca_uk/variables/family.py
@@ -241,10 +241,10 @@ class family_post_tax_income(Variable):
         )
 
 
-class family_net_income(Variable):
+class total_benefit_value(Variable):
     value_type = float
     entity = Family
-    label = u"Net income after taxes and benefits"
+    label = u"Total amount in benefits per week"
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
@@ -271,9 +271,20 @@ class family_net_income(Variable):
             "guardians_allowance_actual",
             "winter_fuel_payments_actual",
         ]
+        return sum(map(lambda benefit: family(benefit, period), benefits))
+
+
+class family_net_income(Variable):
+    value_type = float
+    entity = Family
+    label = u"Net income after taxes and benefits"
+    definition_period = ETERNITY
+
+    def formula(family, period, parameters):
+
         return (
             family("family_total_income", period)
-            + sum(map(lambda benefit: family(benefit, period), benefits))
+            + family("total_benefit_value", period)
             - family.sum(family.members("income_tax", period))
             - family.sum(family.members("NI", period))
             - family("benefit_cap_reduction", period)

--- a/openfisca_uk/variables/family.py
+++ b/openfisca_uk/variables/family.py
@@ -248,7 +248,7 @@ class total_benefit_value(Variable):
     definition_period = ETERNITY
 
     def formula(family, period, parameters):
-        benefits = [
+        BENEFITS = [
             "child_tax_credit",
             "working_tax_credit",
             "child_benefit",


### PR DESCRIPTION
This aims to fix the duplication brought about by #14 by separating the total benefit sum from the net income formula.