### PR TITLE
Add tests

### DIFF
--- a/openfisca_uk/variables/benunit/benefits/computed.py
+++ b/openfisca_uk/variables/benunit/benefits/computed.py
@@ -140,7 +140,9 @@ class tax_credit_reduction(Variable):
         eligible_for_both = (child_tax_credit_amount > 0) * (
             working_tax_credit_amount > 0
         )
-        only_one = (child_tax_credit_amount + working_tax_credit_amount > 0) * (1 - eligible_for_both)
+        only_one = (
+            child_tax_credit_amount + working_tax_credit_amount > 0
+        ) * (1 - eligible_for_both)
         threshold = (
             eligible_for_both
             * parameters(period).benefits.working_tax_credit.income_threshold
@@ -694,7 +696,7 @@ class universal_credit(Variable):
 class ESA_income(Variable):
     value_type = float
     entity = BenUnit
-    label = u'Amount of Employment and Support Allowance per week'
+    label = u"Amount of Employment and Support Allowance per week"
     definition_period = ETERNITY
 
     def formula(benunit, period, parameters):

--- a/setup.py
+++ b/setup.py
@@ -4,9 +4,9 @@ from setuptools import setup, find_packages
 
 setup(
     name="OpenFisca-UK",
-    version="3.9.10",
-    author="OpenFisca Team",
-    author_email="contact@openfisca.org",
+    version="0.1.0",
+    author="UBI Center",
+    author_email="nikhil.woodruff@ubicenter.org",
     classifiers=[
         "Development Status :: 5 - Production/Stable",
         "License :: OSI Approved :: GNU Affero General Public License v3",
@@ -17,7 +17,7 @@ setup(
     description="OpenFisca tax and benefit system for UK",
     keywords="benefit microsimulation social tax",
     license="http://www.fsf.org/licensing/licenses/agpl-3.0.html",
-    url="https://github.com/openfisca/country-template",
+    url="https://github.com/nikhilwoodruff/openfisca-uk",
     include_package_data=True,  # Will read MANIFEST.in
     data_files=[
         (

--- a/tests/benefits/universal_credit.yaml
+++ b/tests/benefits/universal_credit.yaml
@@ -33,3 +33,12 @@
     universal_credit_reported: true
   output:
     universal_credit: 77
+- name: Single person well after phase-out
+  period: 2020-09-07
+  absolute_error_margin: 1
+  input:
+    age: 18
+    employee_earnings: 1400
+    universal_credit_reported: true
+  output:
+    universal_credit: 0


### PR DESCRIPTION
Added some tests for Working Tax Credit, Child Tax Credit, UC and JSA (income-based). It seems some of the parameters from the EUROMOD manual, themselves sourced from [CPAG](https://cpag.org.uk/shop/cpag-titles/welfare-benefits-tax-credits-handbook-202021) aren't matching gov.uk calculators, so they've been updated. 

Also updated contact information in the package install script.